### PR TITLE
Remove need to call BDTestAsync() in all tests

### DIFF
--- a/BDTest/Test/Steps/Then/Then.cs
+++ b/BDTest/Test/Steps/Then/Then.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace BDTest.Test.Steps.Then
@@ -44,5 +45,8 @@ namespace BDTest.Test.Steps.Then
         {
             return await Invoke(TestDetails);
         }
+
+        public TaskAwaiter<Scenario> GetAwaiter()
+            => Invoke(TestDetails).GetAwaiter();
     }
 }

--- a/TestTester/TestsUsingBase.cs
+++ b/TestTester/TestsUsingBase.cs
@@ -29,6 +29,15 @@ namespace TestTester
                 .BDTestAsync();
         }
 
+        [ScenarioText("Asynchronous Scenario With Custom Awaiter")]
+        public async Task AsyncTestCustomAwaiter()
+        {
+            await Given(() => Action1())
+                .When(() => Action2())
+                .Then(() => Action3())
+                .And(() => Action4());
+        }
+
         [Test]
         [ScenarioText("Asynchronous Scenario Failure")]
         public async Task AsyncTestFailure()


### PR DESCRIPTION
By adding a `GetAwaiter()` method to the `Then` class, you can now await a
Then step directly, without needing to call `BDTestAsync()` at the end of
each test.