### PR TITLE
Don't wrap Synchronous exceptions in AggregateException

### DIFF
--- a/BDTest/Test/Steps/Then/Then.cs
+++ b/BDTest/Test/Steps/Then/Then.cs
@@ -37,7 +37,7 @@ namespace BDTest.Test.Steps.Then
 
         public Scenario BDTest()
         {
-            return Invoke(TestDetails).Result;
+            return Invoke(TestDetails).GetAwaiter().GetResult();
         }
 
         public async Task<Scenario> BDTestAsync()

--- a/TestTester/TestsUsingBase.cs
+++ b/TestTester/TestsUsingBase.cs
@@ -41,6 +41,18 @@ namespace TestTester
                 .BDTestAsync();
         }
 
+
+        [Test]
+        [ScenarioText("Synchronous Scenario Failure")]
+        public async Task SyncTestFailure()
+        {
+            Given(() => Action1())
+                .When(() => Action2())
+                .Then(() => Action3())
+                .And(() => Action4())
+                .And(() => Exception(new TestContext()))
+                .BDTest();
+        }
         [Test]
         [ScenarioText("Custom Scenario")]
         public void Test1()


### PR DESCRIPTION
When calling Task.Result, any exceptions get wrapped in an
AggregateException. This does not occur if calling
GetAwaiter().GetResult()